### PR TITLE
build: add allow-root flag when using bower

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clean:
 
 install:
 	$(NPM) install
-	$(BOWER) install $(BOWER_PARAM)
+	$(BOWER) install --allow-root $(BOWER_PARAM)
 
 dev:
 	$(GRUNT) watch


### PR DESCRIPTION
# Add allow-root flag when using bower

Based on the new container configuration we now have to pass the flag `--allow-root` to bower.

It will prevent the `ESUDO` error reported.

```sh
bower install
bower ESUDO         Cannot be run with sudo
```

## :gear: Build

25811ef - build: add allow-root flag when using bower

## :house: Internal

No QC required.