### PR TITLE
build: bump @ovh-ux/ng-ovh-api-wrappers to v4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rollup-plugin-glob-import": "^0.3.1"
   },
   "peerDependencies": {
-    "@ovh-ux/ng-ovh-api-wrappers": "^3.0.0",
+    "@ovh-ux/ng-ovh-api-wrappers": "^4.0.2",
     "@ovh-ux/ng-ovh-swimming-poll": "^4.0.0",
     "angular": "^1.7.8",
     "angular-resource": "^1.7.8"


### PR DESCRIPTION
BREAKING CHANGE: major bump of @ovh-ux/ng-ovh-api-wrappers