### PR TITLE
feat(otb.service): retrieve available release channels

### DIFF
--- a/src/api/overTheBox/overTheBox.v6.service.js
+++ b/src/api/overTheBox/overTheBox.v6.service.js
@@ -109,6 +109,11 @@ angular.module('ovh-api-services').service('OvhApiOverTheBoxV6', ($resource, Ovh
       url: '/overTheBox/:serviceName/device/logs ',
       isArray: false,
     },
+    getAvailableReleaseChannels: {
+      method: 'GET',
+      url: '/overTheBox/:serviceName/availableReleaseChannels',
+      isArray: true,
+    },
   });
 
   return overTheBox;


### PR DESCRIPTION
Add endpoint to retrieve available release channels for OverTheBox

Ref: UXCT-267

Signed-off-by: Stephanie Moallic <stephanie.moallic@corp.ovh.com>