### PR TITLE
Add move for xDSL and Fiber offers

### DIFF
--- a/src/api/connectivity/eligibility/connectivity-eligibility.v6.service.js
+++ b/src/api/connectivity/eligibility/connectivity-eligibility.v6.service.js
@@ -1,8 +1,101 @@
-angular.module('ovh-api-services').service('OvhApiConnectivityEligibilityV6', ($resource, OvhApiConnectivityEligibility) => $resource('/connectivity/eligibility/search/buildingDetails ', {
-}, {
-  buildingDetails: {
-    method: 'POST',
-    isArray: false,
-    cache: OvhApiConnectivityEligibility.cache,
-  },
-}));
+angular.module('ovh-api-services').service('OvhApiConnectivityEligibilityV6', ($resource, Poller) => {
+  const eligibility = $resource('/connectivity/eligibility', {
+  }, {
+    eligibility: {
+      url: '/connectivity/eligibility/test ',
+      method: 'GET',
+      isArray: false,
+      params: {
+        eligibilityReference: '@eligibilityReference',
+      },
+    },
+  });
+
+  eligibility.testAddress = function ($scope, opts) {
+    const url = '/connectivity/eligibility/test/address';
+
+    $scope.$on('$destroy', () => {
+      Poller.kill({
+        scope: $scope.$id,
+      });
+    });
+
+    return Poller.poll(
+      url,
+      null,
+      {
+        postData: {
+          streetCode: opts.streetCode,
+          streetNumber: opts.streetNumber,
+        },
+        successRule: {
+          status(elem) {
+            return elem.status === 'error' || elem.status === 'ok';
+          },
+        },
+        scope: $scope.$id,
+        method: 'POST',
+        retryMaxAttempts: 3,
+      },
+    );
+  };
+
+  eligibility.testBuilding = function ($scope, opts) {
+    const url = '/connectivity/eligibility/test/building';
+
+    $scope.$on('$destroy', () => {
+      Poller.kill({
+        scope: $scope.$id,
+      });
+    });
+
+    return Poller.poll(
+      url,
+      null,
+      {
+        postData: {
+          building: opts.building,
+        },
+        successRule: {
+          status(elem) {
+            return elem.status === 'error' || elem.status === 'ok';
+          },
+        },
+        scope: $scope.$id,
+        method: 'POST',
+        retryMaxAttempts: 3,
+      },
+    );
+  };
+
+  eligibility.testLine = function ($scope, opts) {
+    const url = '/connectivity/eligibility/test/line';
+
+    $scope.$on('$destroy', () => {
+      Poller.kill({
+        scope: $scope.$id,
+      });
+    });
+
+    return Poller.poll(
+      url,
+      null,
+      {
+        postData: {
+          lineNumber: opts.lineNumber,
+          status: opts.status,
+        },
+        successRule: {
+          status(elem) {
+            return elem.status === 'error' || elem.status === 'ok';
+          },
+        },
+        scope: $scope.$id,
+        method: 'POST',
+        retryMaxAttempts: 3,
+      },
+    );
+  };
+
+  return eligibility;
+});

--- a/src/api/connectivity/eligibility/search/connectivity-eligibility-search.service.js
+++ b/src/api/connectivity/eligibility/search/connectivity-eligibility-search.service.js
@@ -1,5 +1,11 @@
-angular.module('ovh-api-services').service('OvhApiConnectivityEligibilitySearch', ($injector) => ({
-  v6() {
-    return $injector.get('OvhApiConnectivityEligibilitySearchV6');
-  },
-}));
+angular.module('ovh-api-services').service('OvhApiConnectivityEligibilitySearch', ($injector, $cacheFactory) => {
+  const cache = $cacheFactory('OvhApiConnectivityEligibilitySearch');
+
+  return {
+    v6() {
+      return $injector.get('OvhApiConnectivityEligibilitySearchV6');
+    },
+    resetCache: cache.removeAll,
+    cache,
+  };
+});

--- a/src/api/connectivity/eligibility/search/connectivity-eligibility-search.v6.service.js
+++ b/src/api/connectivity/eligibility/search/connectivity-eligibility-search.v6.service.js
@@ -1,19 +1,186 @@
-angular.module('ovh-api-services').service('OvhApiConnectivityEligibilitySearchV6', ($resource) => $resource('/connectivity/eligibility/search', {
-}, {
-  searchCities: {
-    url: '/connectivity/eligibility/search/cities',
-    method: 'POST',
-    isArray: false,
-    params: {
-      zipCode: '@zipCode',
+angular.module('ovh-api-services').service('OvhApiConnectivityEligibilitySearchV6', ($resource, OvhApiConnectivityEligibilitySearch, Poller) => {
+  const eligibilitySearch = $resource('/connectivity/eligibility/search', {
+  }, {
+    buildingDetails: {
+      url: '/connectivity/eligibility/search/buildingDetails',
+      method: 'POST',
+      isArray: false,
+      cache: OvhApiConnectivityEligibilitySearch.cache,
     },
-  },
-  searchStreets: {
-    url: '/connectivity/eligibility/search/streets',
-    method: 'POST',
-    isArray: false,
-    params: {
-      inseeCode: '@inseeCode',
-    },
-  },
-}));
+  });
+
+  eligibilitySearch.searchCities = function ($scope, opts) {
+    const url = '/connectivity/eligibility/search/cities';
+
+    $scope.$on('$destroy', () => {
+      Poller.kill({
+        scope: $scope.$id,
+      });
+    });
+
+    return Poller.poll(
+      url,
+      null,
+      {
+        postData: {
+          zipCode: opts.zipCode,
+        },
+        successRule: {
+          status(elem) {
+            return elem.status === 'error' || elem.status === 'ok';
+          },
+        },
+        scope: $scope.$id,
+        method: 'POST',
+        retryMaxAttempts: 3,
+      },
+    );
+  };
+
+  eligibilitySearch.searchStreets = function ($scope, opts) {
+    const url = '/connectivity/eligibility/search/streets';
+
+    $scope.$on('$destroy', () => {
+      Poller.kill({
+        scope: $scope.$id,
+      });
+    });
+
+    return Poller.poll(
+      url,
+      null,
+      {
+        postData: {
+          inseeCode: opts.inseeCode,
+        },
+        successRule: {
+          status(elem) {
+            return elem.status === 'error' || elem.status === 'ok';
+          },
+        },
+        scope: $scope.$id,
+        method: 'POST',
+        retryMaxAttempts: 3,
+      },
+    );
+  };
+
+  eligibilitySearch.searchBuildingByLines = function ($scope, opts) {
+    const url = '/connectivity/eligibility/search/buildingsByLine';
+
+    $scope.$on('$destroy', () => {
+      Poller.kill({
+        scope: $scope.$id,
+      });
+    });
+
+    return Poller.poll(
+      url,
+      null,
+      {
+        postData: {
+          lineNumber: opts.lineNumber,
+          status: opts.status,
+        },
+        successRule: {
+          status(elem) {
+            return elem.status === 'error' || elem.status === 'ok';
+          },
+        },
+        scope: $scope.$id,
+        method: 'POST',
+        retryMaxAttempts: 3,
+      },
+    );
+  };
+
+  eligibilitySearch.searchBuildings = function ($scope, opts) {
+    const url = '/connectivity/eligibility/search/buildings';
+
+    $scope.$on('$destroy', () => {
+      Poller.kill({
+        scope: $scope.$id,
+      });
+    });
+
+    return Poller.poll(
+      url,
+      null,
+      {
+        postData: {
+          streetCode: opts.streetCode,
+          streetNumber: opts.streetNumber,
+        },
+        successRule: {
+          status(elem) {
+            return elem.status === 'error' || elem.status === 'ok';
+          },
+        },
+        scope: $scope.$id,
+        method: 'POST',
+        retryMaxAttempts: 3,
+      },
+    );
+  };
+
+  eligibilitySearch.searchLines = function ($scope, opts) {
+    const url = '/connectivity/eligibility/search/lines';
+
+    $scope.$on('$destroy', () => {
+      Poller.kill({
+        scope: $scope.$id,
+      });
+    });
+
+    return Poller.poll(
+      url,
+      null,
+      {
+        postData: {
+          streetCode: opts.streetCode,
+          streetNumber: opts.streetNumber,
+          ownerName: opts.ownerName,
+        },
+        successRule: {
+          status(elem) {
+            return elem.status === 'error' || elem.status === 'ok';
+          },
+        },
+        scope: $scope.$id,
+        method: 'POST',
+        retryMaxAttempts: 3,
+      },
+    );
+  };
+
+  eligibilitySearch.searchMeetings = function ($scope, opts) {
+    const url = '/connectivity/eligibility/search/meetings';
+
+    $scope.$on('$destroy', () => {
+      Poller.kill({
+        scope: $scope.$id,
+      });
+    });
+
+    return Poller.poll(
+      url,
+      null,
+      {
+        postData: {
+          eligibilityReference: opts.eligibilityReference,
+          productCode: opts.productCode,
+        },
+        successRule: {
+          status(elem) {
+            return elem.status === 'error' || elem.status === 'ok';
+          },
+        },
+        scope: $scope.$id,
+        method: 'POST',
+        retryMaxAttempts: 3,
+      },
+    );
+  };
+
+  return eligibilitySearch;
+});

--- a/src/api/pack/xdsl/move/pack-xdsl-move.v6.service.js
+++ b/src/api/pack/xdsl/move/pack-xdsl-move.v6.service.js
@@ -7,10 +7,15 @@ angular.module('ovh-api-services').service('OvhApiPackXdslMoveV6', ($resource, P
       url: '/pack/xdsl/:packName/addressMove/move',
       isArray: false,
     },
+    moveOffer: {
+      method: 'POST',
+      url: '/pack/xdsl/:packName/addressMove/moveOffer',
+      isArray: false,
+    },
   });
 
   move.pollElligibility = function ($scope, opts) {
-    const url = ['/pack/xdsl/', opts.packName, '/addressMove/eligibility'].join('');
+    const url = `/pack/xdsl/${opts.packName}/addressMove/eligibility`;
 
     $scope.$on('$destroy', () => {
       Poller.kill({
@@ -25,6 +30,34 @@ angular.module('ovh-api-services').service('OvhApiPackXdslMoveV6', ($resource, P
         postData: {
           lineNumber: opts.lineNumber,
           address: opts.address,
+        },
+        successRule: {
+          status(elem) {
+            return elem.status === 'error' || elem.status === 'ok';
+          },
+        },
+        scope: $scope.$id,
+        method: 'post',
+        retryMaxAttempts: 3,
+      },
+    );
+  };
+
+  move.pollOffers = function ($scope, opts) {
+    const url = `/pack/xdsl/${opts.packName}/addressMove/offers`;
+
+    $scope.$on('$destroy', () => {
+      Poller.kill({
+        scope: $scope.$id,
+      });
+    });
+
+    return Poller.poll(
+      url,
+      null,
+      {
+        postData: {
+          eligibilityReference: opts.eligibilityReference,
         },
         successRule: {
           status(elem) {

--- a/src/api/pack/xdsl/pack-xdsl.v6.service.js
+++ b/src/api/pack/xdsl/pack-xdsl.v6.service.js
@@ -77,5 +77,15 @@ angular.module('ovh-api-services').service('OvhApiPackXdslV6', ($resource, OvhAp
         packName: '@packName',
       },
     },
+    getContactOwner: {
+      method: 'GET',
+      url: '/pack/xdsl/:packName/contactOwner',
+      transformResponse(data, headers, status) {
+        if (status === 200) {
+          return { data: angular.fromJson(data) };
+        }
+        return data;
+      },
+    },
   });
 });


### PR DESCRIPTION
Add enpoints on API v6 for :
* eligibility test for copper and fiber lines
* connectivity searches for address and buildings
* moving offer which includes fiber offers
* getting contact owner (which is needed by move offer)

Reference: UXCT-193