### PR TITLE
fix(cloud.project.ai.job): remove non-existing endpoint

### DIFF
--- a/src/api/cloud/project/ai/training/job/cloud-project-ai-training-job.v6.service.js
+++ b/src/api/cloud/project/ai/training/job/cloud-project-ai-training-job.v6.service.js
@@ -8,10 +8,6 @@ angular
       method: 'PUT',
       url: '/cloud/project/:serviceName/ai/job/:jobId/kill',
     },
-    logs: {
-      method: 'GET',
-      url: '/cloud/project/:serviceName/ai/job/:jobId/logs',
-    },
     log: {
       method: 'GET',
       url: '/cloud/project/:serviceName/ai/job/:jobId/log',


### PR DESCRIPTION
## :bug: Bug Fixes

Since product move out from Beta, this looks like a `Breaking Change` but instead we will deprecate `v11.2.0`.

0d847f3 - fix(cloud.project.ai.job): remove non-existing endpoint

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>