### PR TITLE
feat(cloud.storage): include errors in regions in response

### DIFF
--- a/src/api/cloud/project/storage/cloud-project-storage.aapi.service.js
+++ b/src/api/cloud/project/storage/cloud-project-storage.aapi.service.js
@@ -6,7 +6,7 @@ angular.module('ovh-api-services').service('OvhApiCloudProjectStorageAapi', ($re
       method: 'GET',
       serviceType: 'aapi',
       archive: '@archive',
-      isArray: true,
+      isArray: false,
     },
   });
 


### PR DESCRIPTION
 /storages 2API's response is changed from array to object which contains 'resources' and 'errors'
 ref: MANAGER-9662

Signed-off-by: Anoop <anoop.n@ovhcloud.com>

BREAKING-CHANGE: Response of OvhApiCloudProjectStorageAapi.getAll is changed from array to object